### PR TITLE
Fix div by zero

### DIFF
--- a/src/main/java/com/github/rholder/moar/concurrent/thread/BalancingThreadPoolExecutor.java
+++ b/src/main/java/com/github/rholder/moar/concurrent/thread/BalancingThreadPoolExecutor.java
@@ -159,8 +159,10 @@ public class BalancingThreadPoolExecutor extends AbstractExecutorService {
                 cpuTime = liveAvgCpuTotal / liveCount;
             }
 
-            int size = (int) ceil((CPUS * targetUtilization * (1 + (waitTime / cpuTime))));
-            size = size > 0 ? size : 1;
+            int size = 1;
+            if(cpuTime > 0) {
+                size = (int) ceil((CPUS * targetUtilization * (1 + (waitTime / cpuTime))));
+            }
             size = Math.min(size, threadPoolExecutor.getMaximumPoolSize());
 
             // TODO remove debugging


### PR DESCRIPTION
Rearrange size calc to prevent div by zero exception. New calculation works as expected because calculated size can't come out as less than one.

Fixes issue #2 
